### PR TITLE
Fasthttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 
 # middleware
-`import "github.com/zeebox/go-http-middleware"`
+`import "github.com/beamly/go-http-middleware"`
 
 * [Overview](#pkg-overview)
 * [Index](#pkg-index)
@@ -79,32 +79,71 @@ With the response:
 
 
 ## <a name="pkg-index">Index</a>
+* [Constants](#pkg-constants)
+* [type FasthttpHandler](#FasthttpHandler)
 * [type LogEntry](#LogEntry)
 * [type Loggable](#Loggable)
 * [type Middleware](#Middleware)
-  * [func NewMiddleware(h http.Handler) *Middleware](#NewMiddleware)
+  * [func New(h interface{}) *Middleware](#New)
+  * [func NewMiddleware(h interface{}) (m *Middleware)](#NewMiddleware)
   * [func (m *Middleware) AddLogger(l Loggable)](#Middleware.AddLogger)
+  * [func (m *Middleware) ServeFastHTTP(ctx *fasthttp.RequestCtx)](#Middleware.ServeFastHTTP)
   * [func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request)](#Middleware.ServeHTTP)
 
 
 #### <a name="pkg-files">Package files</a>
-[default_logger.go](/src/github.com/zeebox/go-http-middleware/default_logger.go) [doc.go](/src/github.com/zeebox/go-http-middleware/doc.go) [middleware.go](/src/github.com/zeebox/go-http-middleware/middleware.go) 
+[default_logger.go](/src/github.com/beamly/go-http-middleware/default_logger.go) [doc.go](/src/github.com/beamly/go-http-middleware/doc.go) [middleware.go](/src/github.com/beamly/go-http-middleware/middleware.go) 
+
+
+## <a name="pkg-constants">Constants</a>
+``` go
+const (
+    // This is a v5 UUID generated against the DNS namespace
+    // The prescence of this UUID in logs means that UUID generation is broken-
+    // specifically that https://golang.org/pkg/crypto/rand/#Read is returning
+    // an error.
+    //
+    // The URL used to seed this UUID is james-is-great.beamly.com. This domain
+    // does not exist and is, thus, safe to use.
+    DefaultBrokenUUID = "cd9bbcae-e076-549f-82bf-a08e8c838dd3"
+)
+```
+
+
+
+
+## <a name="FasthttpHandler">type</a> [FasthttpHandler](/src/target/middleware.go?s=847:911#L37)
+``` go
+type FasthttpHandler interface {
+    Handle(*fasthttp.RequestCtx)
+}
+```
+FasthttpHandler represents an opinionated fasthttp
+based API handler. Because fasthttp doesn't have the
+concept of a handler interface, like net/http does, we
+need to build our own.
 
 
 
 
 
 
-## <a name="LogEntry">type</a> [LogEntry](/src/target/middleware.go?s=722:973#L27)
+
+
+
+
+## <a name="LogEntry">type</a> [LogEntry](/src/target/middleware.go?s=1442:1742#L58)
 ``` go
 type LogEntry struct {
-    Duration  string    `json:"duration"`
-    IPAddress string    `json:"ip_address"`
-    RequestID string    `json:"request_id"`
-    Status    int       `json:"status"`
-    Time      time.Time `json:"time"`
-    URL       string    `json:"url"`
+    Duration   string    `json:"duration"`
+    DurationMS float64   `json:"duration_ms"`
+    IPAddress  string    `json:"ip_address"`
+    RequestID  string    `json:"request_id"`
+    Status     int       `json:"status"`
+    Time       time.Time `json:"time"`
+    URL        string    `json:"url"`
 }
+
 ```
 LogEntry holds a particular requests data, metadata
 
@@ -117,7 +156,7 @@ LogEntry holds a particular requests data, metadata
 
 
 
-## <a name="Loggable">type</a> [Loggable](/src/target/middleware.go?s=623:665#L22)
+## <a name="Loggable">type</a> [Loggable](/src/target/middleware.go?s=1343:1385#L53)
 ``` go
 type Loggable interface {
     Log(LogEntry)
@@ -134,7 +173,7 @@ Loggable is an interface designed to.... log out
 
 
 
-## <a name="Middleware">type</a> [Middleware](/src/target/middleware.go?s=313:569#L12)
+## <a name="Middleware">type</a> [Middleware](/src/target/middleware.go?s=1034:1289#L43)
 ``` go
 type Middleware struct {
 
@@ -143,6 +182,7 @@ type Middleware struct {
     Requests map[string]*expvar.Int
     // contains filtered or unexported fields
 }
+
 ```
 Middleware handles and stores state for the middleware
 it's self. It, by and large, wraps our handlers and loggers
@@ -153,18 +193,31 @@ it's self. It, by and large, wraps our handlers and loggers
 
 
 
-### <a name="NewMiddleware">func</a> [NewMiddleware](/src/target/middleware.go?s=1063:1109#L38)
+### <a name="New">func</a> [New](/src/target/middleware.go?s=2397:2432#L93)
 ``` go
-func NewMiddleware(h http.Handler) *Middleware
+func New(h interface{}) *Middleware
 ```
-NewMiddleware takes an http handler
+New wraps NewMiddleware- it exists to remove the stutter from
+middleware.NewMiddleware and provide a nicer developer experience
+
+
+### <a name="NewMiddleware">func</a> [NewMiddleware](/src/target/middleware.go?s=1897:1946#L72)
+``` go
+func NewMiddleware(h interface{}) (m *Middleware)
+```
+NewMiddleware takes either:
+
+
+	* a net/http http.Handler; or
+	* a middleware.FasthttpHandler
+
 to wrap and returns mutable Middleware object
 
 
 
 
 
-### <a name="Middleware.AddLogger">func</a> (\*Middleware) [AddLogger](/src/target/middleware.go?s=1391:1433#L50)
+### <a name="Middleware.AddLogger">func</a> (\*Middleware) [AddLogger](/src/target/middleware.go?s=2615:2657#L100)
 ``` go
 func (m *Middleware) AddLogger(l Loggable)
 ```
@@ -175,11 +228,31 @@ to log stuff out
 
 
 
-### <a name="Middleware.ServeHTTP">func</a> (\*Middleware) [ServeHTTP](/src/target/middleware.go?s=2125:2195#L65)
+### <a name="Middleware.ServeFastHTTP">func</a> (\*Middleware) [ServeFastHTTP](/src/target/middleware.go?s=4709:4769#L163)
+``` go
+func (m *Middleware) ServeFastHTTP(ctx *fasthttp.RequestCtx)
+```
+ServeFastHTTP wraps our fasthttp requests and produces useful log lines.
+It does this by wrapping fasthttp compliant endopoints and calling them
+while timing and catching errors.
+
+Log lines are produced as per:
+
+
+	{"duration":"394.823µs","ip_address":"[::1]:62405","request_id":"80d1b249-0b43-4adc-9456-e42e0b942ec0","status":200,"time":"2017-05-27T14:57:48.750350842+01:00","url":"/"}
+
+where `sample-app` is the 'app' string passed into NewMiddleware()
+
+These logs are written to `STDOUT`
+
+
+
+
+### <a name="Middleware.ServeHTTP">func</a> (\*Middleware) [ServeHTTP](/src/target/middleware.go?s=3358:3428#L115)
 ``` go
 func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request)
 ```
-ServeHTTP wraps our requests and produces useful log lines.
+ServeHTTP wraps our net/http requests and produces useful log lines.
 This happens by intercepting the response which the default handler
 responds with and then sending that on outselves. This approach adds
 latency to a response, but it gives us access to things like status codes -


### PR DESCRIPTION
At Culture Trip we tend to use [fasthttp](https://godoc.org/github.com/valyala/fasthttp) in applications where we need super high throughput. This PR will allow us to keep using this package in `fasthttp` based APIs.

I've also updated the docs post migration to the beamly org.